### PR TITLE
fix: repair broken alpha.2 dists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/monorepo",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "homepage": "https://github.com/openvi-foundation/openvue",
     "repository": {
@@ -16,9 +16,10 @@
         "clean": "npx rimraf --glob **/node_modules **/dist **/.nuxt ./pnpm-lock.yaml",
         "init": "pnpm install",
         "link": "pnpm --filter './packages/*' dev:link",
-        "release": "pnpm run build && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary",
-        "release:beta": "pnpm run build && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary --tag beta",
-        "release:rc": "pnpm run build && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary --tag rc",
+        "release": "pnpm run build && pnpm run verify:dist && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary",
+        "release:beta": "pnpm run build && pnpm run verify:dist && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary --tag beta",
+        "release:rc": "pnpm run build && pnpm run verify:dist && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary --tag rc",
+        "verify:dist": "node scripts/verify-dist.mjs",
         "build": "NODE_ENV=production pnpm run build:check && pnpm run build:packages",
         "build:check": "pnpm run format:check && pnpm run security:check",
         "build:packages": "pnpm run build:metadata && pnpm run build:resolver && pnpm run build:core && pnpm run build:lib && pnpm run build:module && pnpm run build:themes && pnpm run build:icons && pnpm run build:mcp && pnpm run build:forms && pnpm run build:migrate && pnpm run build:apps",

--- a/packages/auto-import-resolver/package.json
+++ b/packages/auto-import-resolver/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/auto-import-resolver",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/core",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -25,7 +25,7 @@ const EXTERNALS = [...GLOBAL_EXTERNALS, ...INLINE_EXTERNALS];
 // alias
 const ALIAS_ENTRIES = [
     {
-        find: /^primevue\/core\/(.*)$/,
+        find: /^openvue\/core\/(.*)$/,
         replacement: path.resolve(__dirname, './src/$1'),
         customResolver(source, importer) {
             const basedir = path.dirname(importer);

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -16,7 +16,7 @@
         "incremental": true,
         "baseUrl": ".",
         "paths": {
-            "@primevue/core/*": ["./src/*"]
+            "@openvue/core/*": ["./src/*"]
         }
     },
     "include": ["**/*.ts", "src/*"],

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/forms",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/forms/rollup.config.mjs
+++ b/packages/forms/rollup.config.mjs
@@ -19,13 +19,13 @@ const GLOBALS = {
 
 // externals
 const GLOBAL_EXTERNALS = ['vue'];
-const INLINE_EXTERNALS = [/@primevue\/core\/.*/, /@primeuix\/.*/];
+const INLINE_EXTERNALS = [/@openvue\/core\/.*/, /@primeuix\/.*/];
 const EXTERNALS = [...GLOBAL_EXTERNALS, ...INLINE_EXTERNALS];
 
 // alias
 const ALIAS_ENTRIES = [
     {
-        find: /^@primevue\/forms\/(.*)$/,
+        find: /^@openvue\/forms\/(.*)$/,
         replacement: path.resolve(__dirname, './src/$1'),
         customResolver(source, importer) {
             const basedir = path.dirname(importer);
@@ -43,7 +43,7 @@ const ALIAS_ENTRIES = [
             return targetFile ? path.join(folderPath, targetFile) : null;
         }
     },
-    { find: '@primevue/forms/useform', replacement: path.resolve(__dirname, './src/useform/index.js') }
+    { find: '@openvue/forms/useform', replacement: path.resolve(__dirname, './src/useform/index.js') }
 ];
 
 // plugins

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/icons",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/icons/rollup.config.mjs
+++ b/packages/icons/rollup.config.mjs
@@ -19,13 +19,13 @@ const GLOBALS = {
 
 // externals
 const GLOBAL_EXTERNALS = ['vue'];
-const INLINE_EXTERNALS = [/@primevue\/core\/.*/];
+const INLINE_EXTERNALS = [/@openvue\/core\/.*/];
 const EXTERNALS = [...GLOBAL_EXTERNALS, ...INLINE_EXTERNALS];
 
 // alias
 const ALIAS_ENTRIES = [
     {
-        find: /^@primevue\/icons\/(.*)$/,
+        find: /^@openvue\/icons\/(.*)$/,
         replacement: path.resolve(__dirname, './src/$1'),
         customResolver(source, importer) {
             const basedir = path.dirname(importer);
@@ -43,8 +43,8 @@ const ALIAS_ENTRIES = [
             return targetFile ? path.join(folderPath, targetFile) : null;
         }
     },
-    { find: '@primevue/icons/baseicon/style', replacement: path.resolve(__dirname, './src/baseicon/style/BaseIconStyle.js') },
-    { find: '@primevue/icons/baseicon', replacement: path.resolve(__dirname, './src/baseicon/BaseIcon.vue') }
+    { find: '@openvue/icons/baseicon/style', replacement: path.resolve(__dirname, './src/baseicon/style/BaseIconStyle.js') },
+    { find: '@openvue/icons/baseicon', replacement: path.resolve(__dirname, './src/baseicon/BaseIcon.vue') }
 ];
 
 // plugins

--- a/packages/icons/scripts/prebuild.mjs
+++ b/packages/icons/scripts/prebuild.mjs
@@ -15,7 +15,7 @@ let exports = {};
 let modules = {
     ignoredFolders: [],
     esm: [
-        `/***************** PrimeVue Icons (Auto-Generated) *****************/
+        `/***************** OpenVue Icons (Auto-Generated) *****************/
 `
     ]
 };
@@ -38,8 +38,8 @@ fs.readdirSync(path.resolve(__root, INPUT_DIR), { withFileTypes: true })
                     modules.esm.push(
                         `
 // ${fileName}
-export * from '@primevue/icons/${folderName}';
-export { default as ${fileName} } from '@primevue/icons/${folderName}';
+export * from '@openvue/icons/${folderName}';
+export { default as ${fileName} } from '@openvue/icons/${folderName}';
 `
                     );
                 }
@@ -54,8 +54,8 @@ export { default as ${fileName} } from '@primevue/icons/${folderName}';
 
                             if (validModuleFolder) {
                                 modules.esm.push(
-                                    `export * from '@primevue/icons/${folderName}/style';
-export { default as ${subFileName} } from '@primevue/icons/${folderName}/style';
+                                    `export * from '@openvue/icons/${folderName}/style';
+export { default as ${subFileName} } from '@openvue/icons/${folderName}/style';
 `
                                 );
                             }

--- a/packages/icons/src/index.d.ts
+++ b/packages/icons/src/index.d.ts
@@ -1,195 +1,195 @@
-/***************** PrimeVue Icons (Auto-Generated) *****************/
+/***************** OpenVue Icons (Auto-Generated) *****************/
 
 // AngleDoubleDownIcon
-export * from '@primevue/icons/angledoubledown';
-export { default as AngleDoubleDownIcon } from '@primevue/icons/angledoubledown';
+export * from '@openvue/icons/angledoubledown';
+export { default as AngleDoubleDownIcon } from '@openvue/icons/angledoubledown';
 
 // AngleDoubleLeftIcon
-export * from '@primevue/icons/angledoubleleft';
-export { default as AngleDoubleLeftIcon } from '@primevue/icons/angledoubleleft';
+export * from '@openvue/icons/angledoubleleft';
+export { default as AngleDoubleLeftIcon } from '@openvue/icons/angledoubleleft';
 
 // AngleDoubleRightIcon
-export * from '@primevue/icons/angledoubleright';
-export { default as AngleDoubleRightIcon } from '@primevue/icons/angledoubleright';
+export * from '@openvue/icons/angledoubleright';
+export { default as AngleDoubleRightIcon } from '@openvue/icons/angledoubleright';
 
 // AngleDoubleUpIcon
-export * from '@primevue/icons/angledoubleup';
-export { default as AngleDoubleUpIcon } from '@primevue/icons/angledoubleup';
+export * from '@openvue/icons/angledoubleup';
+export { default as AngleDoubleUpIcon } from '@openvue/icons/angledoubleup';
 
 // AngleDownIcon
-export * from '@primevue/icons/angledown';
-export { default as AngleDownIcon } from '@primevue/icons/angledown';
+export * from '@openvue/icons/angledown';
+export { default as AngleDownIcon } from '@openvue/icons/angledown';
 
 // AngleLeftIcon
-export * from '@primevue/icons/angleleft';
-export { default as AngleLeftIcon } from '@primevue/icons/angleleft';
+export * from '@openvue/icons/angleleft';
+export { default as AngleLeftIcon } from '@openvue/icons/angleleft';
 
 // AngleRightIcon
-export * from '@primevue/icons/angleright';
-export { default as AngleRightIcon } from '@primevue/icons/angleright';
+export * from '@openvue/icons/angleright';
+export { default as AngleRightIcon } from '@openvue/icons/angleright';
 
 // AngleUpIcon
-export * from '@primevue/icons/angleup';
-export { default as AngleUpIcon } from '@primevue/icons/angleup';
+export * from '@openvue/icons/angleup';
+export { default as AngleUpIcon } from '@openvue/icons/angleup';
 
 // ArrowDownIcon
-export * from '@primevue/icons/arrowdown';
-export { default as ArrowDownIcon } from '@primevue/icons/arrowdown';
+export * from '@openvue/icons/arrowdown';
+export { default as ArrowDownIcon } from '@openvue/icons/arrowdown';
 
 // ArrowUpIcon
-export * from '@primevue/icons/arrowup';
-export { default as ArrowUpIcon } from '@primevue/icons/arrowup';
+export * from '@openvue/icons/arrowup';
+export { default as ArrowUpIcon } from '@openvue/icons/arrowup';
 
 // BanIcon
-export * from '@primevue/icons/ban';
-export { default as BanIcon } from '@primevue/icons/ban';
+export * from '@openvue/icons/ban';
+export { default as BanIcon } from '@openvue/icons/ban';
 
 // BarsIcon
-export * from '@primevue/icons/bars';
-export { default as BarsIcon } from '@primevue/icons/bars';
+export * from '@openvue/icons/bars';
+export { default as BarsIcon } from '@openvue/icons/bars';
 
 // BaseIcon
-export * from '@primevue/icons/baseicon';
-export { default as BaseIcon } from '@primevue/icons/baseicon';
-export * from '@primevue/icons/baseicon/style';
-export { default as BaseIconStyle } from '@primevue/icons/baseicon/style';
+export * from '@openvue/icons/baseicon';
+export { default as BaseIcon } from '@openvue/icons/baseicon';
+export * from '@openvue/icons/baseicon/style';
+export { default as BaseIconStyle } from '@openvue/icons/baseicon/style';
 
 // BlankIcon
-export * from '@primevue/icons/blank';
-export { default as BlankIcon } from '@primevue/icons/blank';
+export * from '@openvue/icons/blank';
+export { default as BlankIcon } from '@openvue/icons/blank';
 
 // CalendarIcon
-export * from '@primevue/icons/calendar';
-export { default as CalendarIcon } from '@primevue/icons/calendar';
+export * from '@openvue/icons/calendar';
+export { default as CalendarIcon } from '@openvue/icons/calendar';
 
 // CheckIcon
-export * from '@primevue/icons/check';
-export { default as CheckIcon } from '@primevue/icons/check';
+export * from '@openvue/icons/check';
+export { default as CheckIcon } from '@openvue/icons/check';
 
 // ChevronDownIcon
-export * from '@primevue/icons/chevrondown';
-export { default as ChevronDownIcon } from '@primevue/icons/chevrondown';
+export * from '@openvue/icons/chevrondown';
+export { default as ChevronDownIcon } from '@openvue/icons/chevrondown';
 
 // ChevronLeftIcon
-export * from '@primevue/icons/chevronleft';
-export { default as ChevronLeftIcon } from '@primevue/icons/chevronleft';
+export * from '@openvue/icons/chevronleft';
+export { default as ChevronLeftIcon } from '@openvue/icons/chevronleft';
 
 // ChevronRightIcon
-export * from '@primevue/icons/chevronright';
-export { default as ChevronRightIcon } from '@primevue/icons/chevronright';
+export * from '@openvue/icons/chevronright';
+export { default as ChevronRightIcon } from '@openvue/icons/chevronright';
 
 // ChevronUpIcon
-export * from '@primevue/icons/chevronup';
-export { default as ChevronUpIcon } from '@primevue/icons/chevronup';
+export * from '@openvue/icons/chevronup';
+export { default as ChevronUpIcon } from '@openvue/icons/chevronup';
 
 // ExclamationTriangleIcon
-export * from '@primevue/icons/exclamationtriangle';
-export { default as ExclamationTriangleIcon } from '@primevue/icons/exclamationtriangle';
+export * from '@openvue/icons/exclamationtriangle';
+export { default as ExclamationTriangleIcon } from '@openvue/icons/exclamationtriangle';
 
 // EyeIcon
-export * from '@primevue/icons/eye';
-export { default as EyeIcon } from '@primevue/icons/eye';
+export * from '@openvue/icons/eye';
+export { default as EyeIcon } from '@openvue/icons/eye';
 
 // EyeSlashIcon
-export * from '@primevue/icons/eyeslash';
-export { default as EyeSlashIcon } from '@primevue/icons/eyeslash';
+export * from '@openvue/icons/eyeslash';
+export { default as EyeSlashIcon } from '@openvue/icons/eyeslash';
 
 // FilterIcon
-export * from '@primevue/icons/filter';
-export { default as FilterIcon } from '@primevue/icons/filter';
+export * from '@openvue/icons/filter';
+export { default as FilterIcon } from '@openvue/icons/filter';
 
 // FilterFillIcon
-export * from '@primevue/icons/filterfill';
-export { default as FilterFillIcon } from '@primevue/icons/filterfill';
+export * from '@openvue/icons/filterfill';
+export { default as FilterFillIcon } from '@openvue/icons/filterfill';
 
 // FilterSlashIcon
-export * from '@primevue/icons/filterslash';
-export { default as FilterSlashIcon } from '@primevue/icons/filterslash';
+export * from '@openvue/icons/filterslash';
+export { default as FilterSlashIcon } from '@openvue/icons/filterslash';
 
 // InfoCircleIcon
-export * from '@primevue/icons/infocircle';
-export { default as InfoCircleIcon } from '@primevue/icons/infocircle';
+export * from '@openvue/icons/infocircle';
+export { default as InfoCircleIcon } from '@openvue/icons/infocircle';
 
 // MinusIcon
-export * from '@primevue/icons/minus';
-export { default as MinusIcon } from '@primevue/icons/minus';
+export * from '@openvue/icons/minus';
+export { default as MinusIcon } from '@openvue/icons/minus';
 
 // PencilIcon
-export * from '@primevue/icons/pencil';
-export { default as PencilIcon } from '@primevue/icons/pencil';
+export * from '@openvue/icons/pencil';
+export { default as PencilIcon } from '@openvue/icons/pencil';
 
 // PlusIcon
-export * from '@primevue/icons/plus';
-export { default as PlusIcon } from '@primevue/icons/plus';
+export * from '@openvue/icons/plus';
+export { default as PlusIcon } from '@openvue/icons/plus';
 
 // RefreshIcon
-export * from '@primevue/icons/refresh';
-export { default as RefreshIcon } from '@primevue/icons/refresh';
+export * from '@openvue/icons/refresh';
+export { default as RefreshIcon } from '@openvue/icons/refresh';
 
 // SearchIcon
-export * from '@primevue/icons/search';
-export { default as SearchIcon } from '@primevue/icons/search';
+export * from '@openvue/icons/search';
+export { default as SearchIcon } from '@openvue/icons/search';
 
 // SearchMinusIcon
-export * from '@primevue/icons/searchminus';
-export { default as SearchMinusIcon } from '@primevue/icons/searchminus';
+export * from '@openvue/icons/searchminus';
+export { default as SearchMinusIcon } from '@openvue/icons/searchminus';
 
 // SearchPlusIcon
-export * from '@primevue/icons/searchplus';
-export { default as SearchPlusIcon } from '@primevue/icons/searchplus';
+export * from '@openvue/icons/searchplus';
+export { default as SearchPlusIcon } from '@openvue/icons/searchplus';
 
 // SortAltIcon
-export * from '@primevue/icons/sortalt';
-export { default as SortAltIcon } from '@primevue/icons/sortalt';
+export * from '@openvue/icons/sortalt';
+export { default as SortAltIcon } from '@openvue/icons/sortalt';
 
 // SortAmountDownIcon
-export * from '@primevue/icons/sortamountdown';
-export { default as SortAmountDownIcon } from '@primevue/icons/sortamountdown';
+export * from '@openvue/icons/sortamountdown';
+export { default as SortAmountDownIcon } from '@openvue/icons/sortamountdown';
 
 // SortAmountUpAltIcon
-export * from '@primevue/icons/sortamountupalt';
-export { default as SortAmountUpAltIcon } from '@primevue/icons/sortamountupalt';
+export * from '@openvue/icons/sortamountupalt';
+export { default as SortAmountUpAltIcon } from '@openvue/icons/sortamountupalt';
 
 // SpinnerIcon
-export * from '@primevue/icons/spinner';
-export { default as SpinnerIcon } from '@primevue/icons/spinner';
+export * from '@openvue/icons/spinner';
+export { default as SpinnerIcon } from '@openvue/icons/spinner';
 
 // StarIcon
-export * from '@primevue/icons/star';
-export { default as StarIcon } from '@primevue/icons/star';
+export * from '@openvue/icons/star';
+export { default as StarIcon } from '@openvue/icons/star';
 
 // StarFillIcon
-export * from '@primevue/icons/starfill';
-export { default as StarFillIcon } from '@primevue/icons/starfill';
+export * from '@openvue/icons/starfill';
+export { default as StarFillIcon } from '@openvue/icons/starfill';
 
 // ThLargeIcon
-export * from '@primevue/icons/thlarge';
-export { default as ThLargeIcon } from '@primevue/icons/thlarge';
+export * from '@openvue/icons/thlarge';
+export { default as ThLargeIcon } from '@openvue/icons/thlarge';
 
 // TimesIcon
-export * from '@primevue/icons/times';
-export { default as TimesIcon } from '@primevue/icons/times';
+export * from '@openvue/icons/times';
+export { default as TimesIcon } from '@openvue/icons/times';
 
 // TimesCircleIcon
-export * from '@primevue/icons/timescircle';
-export { default as TimesCircleIcon } from '@primevue/icons/timescircle';
+export * from '@openvue/icons/timescircle';
+export { default as TimesCircleIcon } from '@openvue/icons/timescircle';
 
 // TrashIcon
-export * from '@primevue/icons/trash';
-export { default as TrashIcon } from '@primevue/icons/trash';
+export * from '@openvue/icons/trash';
+export { default as TrashIcon } from '@openvue/icons/trash';
 
 // UndoIcon
-export * from '@primevue/icons/undo';
-export { default as UndoIcon } from '@primevue/icons/undo';
+export * from '@openvue/icons/undo';
+export { default as UndoIcon } from '@openvue/icons/undo';
 
 // UploadIcon
-export * from '@primevue/icons/upload';
-export { default as UploadIcon } from '@primevue/icons/upload';
+export * from '@openvue/icons/upload';
+export { default as UploadIcon } from '@openvue/icons/upload';
 
 // WindowMaximizeIcon
-export * from '@primevue/icons/windowmaximize';
-export { default as WindowMaximizeIcon } from '@primevue/icons/windowmaximize';
+export * from '@openvue/icons/windowmaximize';
+export { default as WindowMaximizeIcon } from '@openvue/icons/windowmaximize';
 
 // WindowMinimizeIcon
-export * from '@primevue/icons/windowminimize';
-export { default as WindowMinimizeIcon } from '@primevue/icons/windowminimize';
+export * from '@openvue/icons/windowminimize';
+export { default as WindowMinimizeIcon } from '@openvue/icons/windowminimize';

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -1,195 +1,195 @@
-/***************** PrimeVue Icons (Auto-Generated) *****************/
+/***************** OpenVue Icons (Auto-Generated) *****************/
 
 // AngleDoubleDownIcon
-export * from '@primevue/icons/angledoubledown';
-export { default as AngleDoubleDownIcon } from '@primevue/icons/angledoubledown';
+export * from '@openvue/icons/angledoubledown';
+export { default as AngleDoubleDownIcon } from '@openvue/icons/angledoubledown';
 
 // AngleDoubleLeftIcon
-export * from '@primevue/icons/angledoubleleft';
-export { default as AngleDoubleLeftIcon } from '@primevue/icons/angledoubleleft';
+export * from '@openvue/icons/angledoubleleft';
+export { default as AngleDoubleLeftIcon } from '@openvue/icons/angledoubleleft';
 
 // AngleDoubleRightIcon
-export * from '@primevue/icons/angledoubleright';
-export { default as AngleDoubleRightIcon } from '@primevue/icons/angledoubleright';
+export * from '@openvue/icons/angledoubleright';
+export { default as AngleDoubleRightIcon } from '@openvue/icons/angledoubleright';
 
 // AngleDoubleUpIcon
-export * from '@primevue/icons/angledoubleup';
-export { default as AngleDoubleUpIcon } from '@primevue/icons/angledoubleup';
+export * from '@openvue/icons/angledoubleup';
+export { default as AngleDoubleUpIcon } from '@openvue/icons/angledoubleup';
 
 // AngleDownIcon
-export * from '@primevue/icons/angledown';
-export { default as AngleDownIcon } from '@primevue/icons/angledown';
+export * from '@openvue/icons/angledown';
+export { default as AngleDownIcon } from '@openvue/icons/angledown';
 
 // AngleLeftIcon
-export * from '@primevue/icons/angleleft';
-export { default as AngleLeftIcon } from '@primevue/icons/angleleft';
+export * from '@openvue/icons/angleleft';
+export { default as AngleLeftIcon } from '@openvue/icons/angleleft';
 
 // AngleRightIcon
-export * from '@primevue/icons/angleright';
-export { default as AngleRightIcon } from '@primevue/icons/angleright';
+export * from '@openvue/icons/angleright';
+export { default as AngleRightIcon } from '@openvue/icons/angleright';
 
 // AngleUpIcon
-export * from '@primevue/icons/angleup';
-export { default as AngleUpIcon } from '@primevue/icons/angleup';
+export * from '@openvue/icons/angleup';
+export { default as AngleUpIcon } from '@openvue/icons/angleup';
 
 // ArrowDownIcon
-export * from '@primevue/icons/arrowdown';
-export { default as ArrowDownIcon } from '@primevue/icons/arrowdown';
+export * from '@openvue/icons/arrowdown';
+export { default as ArrowDownIcon } from '@openvue/icons/arrowdown';
 
 // ArrowUpIcon
-export * from '@primevue/icons/arrowup';
-export { default as ArrowUpIcon } from '@primevue/icons/arrowup';
+export * from '@openvue/icons/arrowup';
+export { default as ArrowUpIcon } from '@openvue/icons/arrowup';
 
 // BanIcon
-export * from '@primevue/icons/ban';
-export { default as BanIcon } from '@primevue/icons/ban';
+export * from '@openvue/icons/ban';
+export { default as BanIcon } from '@openvue/icons/ban';
 
 // BarsIcon
-export * from '@primevue/icons/bars';
-export { default as BarsIcon } from '@primevue/icons/bars';
+export * from '@openvue/icons/bars';
+export { default as BarsIcon } from '@openvue/icons/bars';
 
 // BaseIcon
-export * from '@primevue/icons/baseicon';
-export { default as BaseIcon } from '@primevue/icons/baseicon';
-export * from '@primevue/icons/baseicon/style';
-export { default as BaseIconStyle } from '@primevue/icons/baseicon/style';
+export * from '@openvue/icons/baseicon';
+export { default as BaseIcon } from '@openvue/icons/baseicon';
+export * from '@openvue/icons/baseicon/style';
+export { default as BaseIconStyle } from '@openvue/icons/baseicon/style';
 
 // BlankIcon
-export * from '@primevue/icons/blank';
-export { default as BlankIcon } from '@primevue/icons/blank';
+export * from '@openvue/icons/blank';
+export { default as BlankIcon } from '@openvue/icons/blank';
 
 // CalendarIcon
-export * from '@primevue/icons/calendar';
-export { default as CalendarIcon } from '@primevue/icons/calendar';
+export * from '@openvue/icons/calendar';
+export { default as CalendarIcon } from '@openvue/icons/calendar';
 
 // CheckIcon
-export * from '@primevue/icons/check';
-export { default as CheckIcon } from '@primevue/icons/check';
+export * from '@openvue/icons/check';
+export { default as CheckIcon } from '@openvue/icons/check';
 
 // ChevronDownIcon
-export * from '@primevue/icons/chevrondown';
-export { default as ChevronDownIcon } from '@primevue/icons/chevrondown';
+export * from '@openvue/icons/chevrondown';
+export { default as ChevronDownIcon } from '@openvue/icons/chevrondown';
 
 // ChevronLeftIcon
-export * from '@primevue/icons/chevronleft';
-export { default as ChevronLeftIcon } from '@primevue/icons/chevronleft';
+export * from '@openvue/icons/chevronleft';
+export { default as ChevronLeftIcon } from '@openvue/icons/chevronleft';
 
 // ChevronRightIcon
-export * from '@primevue/icons/chevronright';
-export { default as ChevronRightIcon } from '@primevue/icons/chevronright';
+export * from '@openvue/icons/chevronright';
+export { default as ChevronRightIcon } from '@openvue/icons/chevronright';
 
 // ChevronUpIcon
-export * from '@primevue/icons/chevronup';
-export { default as ChevronUpIcon } from '@primevue/icons/chevronup';
+export * from '@openvue/icons/chevronup';
+export { default as ChevronUpIcon } from '@openvue/icons/chevronup';
 
 // ExclamationTriangleIcon
-export * from '@primevue/icons/exclamationtriangle';
-export { default as ExclamationTriangleIcon } from '@primevue/icons/exclamationtriangle';
+export * from '@openvue/icons/exclamationtriangle';
+export { default as ExclamationTriangleIcon } from '@openvue/icons/exclamationtriangle';
 
 // EyeIcon
-export * from '@primevue/icons/eye';
-export { default as EyeIcon } from '@primevue/icons/eye';
+export * from '@openvue/icons/eye';
+export { default as EyeIcon } from '@openvue/icons/eye';
 
 // EyeSlashIcon
-export * from '@primevue/icons/eyeslash';
-export { default as EyeSlashIcon } from '@primevue/icons/eyeslash';
+export * from '@openvue/icons/eyeslash';
+export { default as EyeSlashIcon } from '@openvue/icons/eyeslash';
 
 // FilterIcon
-export * from '@primevue/icons/filter';
-export { default as FilterIcon } from '@primevue/icons/filter';
+export * from '@openvue/icons/filter';
+export { default as FilterIcon } from '@openvue/icons/filter';
 
 // FilterFillIcon
-export * from '@primevue/icons/filterfill';
-export { default as FilterFillIcon } from '@primevue/icons/filterfill';
+export * from '@openvue/icons/filterfill';
+export { default as FilterFillIcon } from '@openvue/icons/filterfill';
 
 // FilterSlashIcon
-export * from '@primevue/icons/filterslash';
-export { default as FilterSlashIcon } from '@primevue/icons/filterslash';
+export * from '@openvue/icons/filterslash';
+export { default as FilterSlashIcon } from '@openvue/icons/filterslash';
 
 // InfoCircleIcon
-export * from '@primevue/icons/infocircle';
-export { default as InfoCircleIcon } from '@primevue/icons/infocircle';
+export * from '@openvue/icons/infocircle';
+export { default as InfoCircleIcon } from '@openvue/icons/infocircle';
 
 // MinusIcon
-export * from '@primevue/icons/minus';
-export { default as MinusIcon } from '@primevue/icons/minus';
+export * from '@openvue/icons/minus';
+export { default as MinusIcon } from '@openvue/icons/minus';
 
 // PencilIcon
-export * from '@primevue/icons/pencil';
-export { default as PencilIcon } from '@primevue/icons/pencil';
+export * from '@openvue/icons/pencil';
+export { default as PencilIcon } from '@openvue/icons/pencil';
 
 // PlusIcon
-export * from '@primevue/icons/plus';
-export { default as PlusIcon } from '@primevue/icons/plus';
+export * from '@openvue/icons/plus';
+export { default as PlusIcon } from '@openvue/icons/plus';
 
 // RefreshIcon
-export * from '@primevue/icons/refresh';
-export { default as RefreshIcon } from '@primevue/icons/refresh';
+export * from '@openvue/icons/refresh';
+export { default as RefreshIcon } from '@openvue/icons/refresh';
 
 // SearchIcon
-export * from '@primevue/icons/search';
-export { default as SearchIcon } from '@primevue/icons/search';
+export * from '@openvue/icons/search';
+export { default as SearchIcon } from '@openvue/icons/search';
 
 // SearchMinusIcon
-export * from '@primevue/icons/searchminus';
-export { default as SearchMinusIcon } from '@primevue/icons/searchminus';
+export * from '@openvue/icons/searchminus';
+export { default as SearchMinusIcon } from '@openvue/icons/searchminus';
 
 // SearchPlusIcon
-export * from '@primevue/icons/searchplus';
-export { default as SearchPlusIcon } from '@primevue/icons/searchplus';
+export * from '@openvue/icons/searchplus';
+export { default as SearchPlusIcon } from '@openvue/icons/searchplus';
 
 // SortAltIcon
-export * from '@primevue/icons/sortalt';
-export { default as SortAltIcon } from '@primevue/icons/sortalt';
+export * from '@openvue/icons/sortalt';
+export { default as SortAltIcon } from '@openvue/icons/sortalt';
 
 // SortAmountDownIcon
-export * from '@primevue/icons/sortamountdown';
-export { default as SortAmountDownIcon } from '@primevue/icons/sortamountdown';
+export * from '@openvue/icons/sortamountdown';
+export { default as SortAmountDownIcon } from '@openvue/icons/sortamountdown';
 
 // SortAmountUpAltIcon
-export * from '@primevue/icons/sortamountupalt';
-export { default as SortAmountUpAltIcon } from '@primevue/icons/sortamountupalt';
+export * from '@openvue/icons/sortamountupalt';
+export { default as SortAmountUpAltIcon } from '@openvue/icons/sortamountupalt';
 
 // SpinnerIcon
-export * from '@primevue/icons/spinner';
-export { default as SpinnerIcon } from '@primevue/icons/spinner';
+export * from '@openvue/icons/spinner';
+export { default as SpinnerIcon } from '@openvue/icons/spinner';
 
 // StarIcon
-export * from '@primevue/icons/star';
-export { default as StarIcon } from '@primevue/icons/star';
+export * from '@openvue/icons/star';
+export { default as StarIcon } from '@openvue/icons/star';
 
 // StarFillIcon
-export * from '@primevue/icons/starfill';
-export { default as StarFillIcon } from '@primevue/icons/starfill';
+export * from '@openvue/icons/starfill';
+export { default as StarFillIcon } from '@openvue/icons/starfill';
 
 // ThLargeIcon
-export * from '@primevue/icons/thlarge';
-export { default as ThLargeIcon } from '@primevue/icons/thlarge';
+export * from '@openvue/icons/thlarge';
+export { default as ThLargeIcon } from '@openvue/icons/thlarge';
 
 // TimesIcon
-export * from '@primevue/icons/times';
-export { default as TimesIcon } from '@primevue/icons/times';
+export * from '@openvue/icons/times';
+export { default as TimesIcon } from '@openvue/icons/times';
 
 // TimesCircleIcon
-export * from '@primevue/icons/timescircle';
-export { default as TimesCircleIcon } from '@primevue/icons/timescircle';
+export * from '@openvue/icons/timescircle';
+export { default as TimesCircleIcon } from '@openvue/icons/timescircle';
 
 // TrashIcon
-export * from '@primevue/icons/trash';
-export { default as TrashIcon } from '@primevue/icons/trash';
+export * from '@openvue/icons/trash';
+export { default as TrashIcon } from '@openvue/icons/trash';
 
 // UndoIcon
-export * from '@primevue/icons/undo';
-export { default as UndoIcon } from '@primevue/icons/undo';
+export * from '@openvue/icons/undo';
+export { default as UndoIcon } from '@openvue/icons/undo';
 
 // UploadIcon
-export * from '@primevue/icons/upload';
-export { default as UploadIcon } from '@primevue/icons/upload';
+export * from '@openvue/icons/upload';
+export { default as UploadIcon } from '@openvue/icons/upload';
 
 // WindowMaximizeIcon
-export * from '@primevue/icons/windowmaximize';
-export { default as WindowMaximizeIcon } from '@primevue/icons/windowmaximize';
+export * from '@openvue/icons/windowmaximize';
+export { default as WindowMaximizeIcon } from '@openvue/icons/windowmaximize';
 
 // WindowMinimizeIcon
-export * from '@primevue/icons/windowminimize';
-export { default as WindowMinimizeIcon } from '@primevue/icons/windowminimize';
+export * from '@openvue/icons/windowminimize';
+export { default as WindowMinimizeIcon } from '@openvue/icons/windowminimize';

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -16,8 +16,8 @@
         "incremental": true,
         "baseUrl": ".",
         "paths": {
-            "@primevue/icons/*": ["./src/*"],
-            "@primevue/core/*": ["../../packages/core/src/*"]
+            "@openvue/icons/*": ["./src/*"],
+            "@openvue/core/*": ["../../packages/core/src/*"]
         }
     },
     "include": ["**/*.ts", "src/*"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/mcp",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "Model Context Protocol (MCP) server for PrimeVue component library",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     entry: ['./src/index.ts'],
     format: ['esm'],
     dts: true,
-    external: [/^@primeuix\/(.*)$/, /^@primevue\/(.*)$/],
+    external: [/^@primeuix\/(.*)$/, /^@openvue\/(.*)$/],
     splitting: false,
     clean: true,
     shims: true,

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/metadata",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/migrate",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "Codemod that migrates a PrimeVue project to OpenVue by rewriting package names and import specifiers",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/migrate/test/fixtures.spec.ts
+++ b/packages/migrate/test/fixtures.spec.ts
@@ -26,13 +26,17 @@ function copyFixture(name: string): string {
     return dir;
 }
 
+// git checkout may normalize fixture line endings differently per platform,
+// so compare with LF-normalized content
+const normalizeEol = (text: string) => text.replaceAll('\r\n', '\n');
+
 function assertMatchesExpected(migratedDir: string, name: string) {
     const expectedDir = join(FIXTURES, name, 'after');
 
     for (const expectedFile of walk(expectedDir)) {
         const relativePath = relative(expectedDir, expectedFile);
-        const expected = readFileSync(expectedFile, 'utf8').replaceAll('__OPENVUE_VERSION__', OPENVUE_VERSION);
-        const actual = readFileSync(join(migratedDir, relativePath), 'utf8');
+        const expected = normalizeEol(readFileSync(expectedFile, 'utf8')).replaceAll('__OPENVUE_VERSION__', OPENVUE_VERSION);
+        const actual = normalizeEol(readFileSync(join(migratedDir, relativePath), 'utf8'));
 
         expect(actual, relativePath).toBe(expected);
     }

--- a/packages/nuxt-module/package.json
+++ b/packages/nuxt-module/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/nuxt-module",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "Nuxt module for PrimeVue",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/nuxt-module/tsconfig.json
+++ b/packages/nuxt-module/tsconfig.json
@@ -4,9 +4,9 @@
         "moduleResolution": "Node",
         "baseUrl": ".",
         "paths": {
-            "primevue/*": ["../../packages/primevue/src/*"],
-            "@primevue/metadata/*": ["../../packages/metadata/src/*"],
-            "@primevue/auto-import-resolver/*": ["../../packages/auto-import-resolver/src/*"]
+            "openvue/*": ["../../packages/primevue/src/*"],
+            "@openvue/metadata/*": ["../../packages/metadata/src/*"],
+            "@openvue/auto-import-resolver/*": ["../../packages/auto-import-resolver/src/*"]
         }
     },
     "exclude": ["dist", "node_modules", "playground"]

--- a/packages/primevue/package.json
+++ b/packages/primevue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openvue",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "PrimeVue is an open source UI library for Vue featuring a rich set of 80+ components, a theme designer, various theme alternatives such as Material, Bootstrap, Tailwind, premium templates and professional support. In addition, it integrates with PrimeBlock, which has 370+ ready to use UI blocks to build spectacular applications in no time.",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/primevue/rollup.config.mjs
+++ b/packages/primevue/rollup.config.mjs
@@ -19,13 +19,13 @@ const GLOBALS = {
 
 // externals
 const GLOBAL_EXTERNALS = ['vue', 'chart.js/auto', 'quill'];
-const INLINE_EXTERNALS = [/@primevue\/core\/.*/, /@primevue\/icons\/.*/, '@primeuix/styled', /@primeuix\/utils\/.*/];
+const INLINE_EXTERNALS = [/@openvue\/core\/.*/, /@openvue\/icons\/.*/, '@primeuix/styled', /@primeuix\/utils\/.*/];
 const EXTERNALS = [...GLOBAL_EXTERNALS, ...INLINE_EXTERNALS];
 
 // alias
 const ALIAS_ENTRIES = [
     {
-        find: /^primevue\/(.*)$/,
+        find: /^openvue\/(.*)$/,
         replacement: path.resolve(__dirname, './src/$1'),
         customResolver(source, importer) {
             const basedir = path.dirname(importer);
@@ -44,23 +44,23 @@ const ALIAS_ENTRIES = [
         }
     },
     // @todo - Remove
-    { find: '@primevue/core/api', replacement: path.resolve(__dirname, '../core/src/api/Api.js') },
-    { find: '@primevue/core/base/style', replacement: path.resolve(__dirname, '../core/src/base/style/BaseStyle.js') },
-    { find: '@primevue/core/base', replacement: path.resolve(__dirname, '../core/src/base/Base.js') },
-    { find: '@primevue/core/basecomponent/style', replacement: path.resolve(__dirname, '../core/src/basecomponent/style/BaseComponentStyle.js') },
-    { find: '@primevue/core/basecomponent', replacement: path.resolve(__dirname, '../core/src/basecomponent/BaseComponent.vue') },
-    { find: '@primevue/core/basedirective', replacement: path.resolve(__dirname, '../core/src/basedirective/BaseDirective.js') },
-    { find: '@primevue/core/baseeditableholder', replacement: path.resolve(__dirname, '../core/src/baseeditableholder/BaseEditableHolder.vue') },
-    { find: '@primevue/core/baseinput', replacement: path.resolve(__dirname, '../core/src/baseinput/BaseInput.vue') },
-    { find: '@primevue/core/config', replacement: path.resolve(__dirname, '../core/src/config/PrimeVue.js') },
-    { find: '@primevue/core/service', replacement: path.resolve(__dirname, '../core/src/service/PrimeVueService.js') },
-    { find: '@primevue/core/useattrselector', replacement: path.resolve(__dirname, '../core/src/useattrselector/UseAttrSelector.js') },
-    { find: '@primevue/core/useid', replacement: path.resolve(__dirname, '../core/src/useid/UseId.js') },
-    { find: '@primevue/core/usestyle', replacement: path.resolve(__dirname, '../core/src/usestyle/UseStyle.js') },
-    { find: '@primevue/core/utils', replacement: path.resolve(__dirname, '../core/src/utils/Utils.js') },
-    { find: '@primevue/core', replacement: path.resolve(__dirname, '../core/src/index.js') },
-    { find: '@primevue/icons/baseicon/style', replacement: path.resolve(__dirname, '../icons/src/baseicon/style/BaseIconStyle.js') },
-    { find: '@primevue/icons/baseicon', replacement: path.resolve(__dirname, '../icons/src/baseicon/BaseIcon.vue') }
+    { find: '@openvue/core/api', replacement: path.resolve(__dirname, '../core/src/api/Api.js') },
+    { find: '@openvue/core/base/style', replacement: path.resolve(__dirname, '../core/src/base/style/BaseStyle.js') },
+    { find: '@openvue/core/base', replacement: path.resolve(__dirname, '../core/src/base/Base.js') },
+    { find: '@openvue/core/basecomponent/style', replacement: path.resolve(__dirname, '../core/src/basecomponent/style/BaseComponentStyle.js') },
+    { find: '@openvue/core/basecomponent', replacement: path.resolve(__dirname, '../core/src/basecomponent/BaseComponent.vue') },
+    { find: '@openvue/core/basedirective', replacement: path.resolve(__dirname, '../core/src/basedirective/BaseDirective.js') },
+    { find: '@openvue/core/baseeditableholder', replacement: path.resolve(__dirname, '../core/src/baseeditableholder/BaseEditableHolder.vue') },
+    { find: '@openvue/core/baseinput', replacement: path.resolve(__dirname, '../core/src/baseinput/BaseInput.vue') },
+    { find: '@openvue/core/config', replacement: path.resolve(__dirname, '../core/src/config/PrimeVue.js') },
+    { find: '@openvue/core/service', replacement: path.resolve(__dirname, '../core/src/service/PrimeVueService.js') },
+    { find: '@openvue/core/useattrselector', replacement: path.resolve(__dirname, '../core/src/useattrselector/UseAttrSelector.js') },
+    { find: '@openvue/core/useid', replacement: path.resolve(__dirname, '../core/src/useid/UseId.js') },
+    { find: '@openvue/core/usestyle', replacement: path.resolve(__dirname, '../core/src/usestyle/UseStyle.js') },
+    { find: '@openvue/core/utils', replacement: path.resolve(__dirname, '../core/src/utils/Utils.js') },
+    { find: '@openvue/core', replacement: path.resolve(__dirname, '../core/src/index.js') },
+    { find: '@openvue/icons/baseicon/style', replacement: path.resolve(__dirname, '../icons/src/baseicon/style/BaseIconStyle.js') },
+    { find: '@openvue/icons/baseicon', replacement: path.resolve(__dirname, '../icons/src/baseicon/BaseIcon.vue') }
 ];
 
 // plugins

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openvue/themes",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "author": "OpenVue Contributors",
     "description": "",
     "homepage": "https://github.com/openvi-foundation/openvue",

--- a/packages/themes/rollup.config.mjs
+++ b/packages/themes/rollup.config.mjs
@@ -22,7 +22,7 @@ const EXTERNALS = [];
 // alias
 const ALIAS_ENTRIES = [
     {
-        find: /^@primevue\/themes\/(.*)$/,
+        find: /^@openvue\/themes\/(.*)$/,
         replacement: path.resolve(__dirname, './src/presets/$1/index.js')
     }
 ];
@@ -175,7 +175,8 @@ function addThemes() {
         (file) => file === 'index.js',
         (file, filePath, folderPath) => {
             const searchFolder = '/' + process.env.INPUT_DIR;
-            const folderName = folderPath.substring(folderPath.indexOf(searchFolder) + searchFolder.length);
+            const normalizedPath = folderPath.split(path.sep).join('/');
+            const folderName = normalizedPath.substring(normalizedPath.indexOf(searchFolder) + searchFolder.length);
             const input = process.env.INPUT_DIR + folderName + '/' + file;
             const output = process.env.OUTPUT_DIR + folderName.replace('presets/', '') + '/index';
 

--- a/packages/themes/tsconfig.json
+++ b/packages/themes/tsconfig.json
@@ -16,7 +16,7 @@
         "incremental": true,
         "baseUrl": ".",
         "paths": {
-            "@primevue/themes/*": ["./src/*"]
+            "@openvue/themes/*": ["./src/*"]
         }
     },
     "include": ["**/*.ts", "src/*"],

--- a/scripts/verify-dist.mjs
+++ b/scripts/verify-dist.mjs
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+// Fails the build when a packages/*/dist artifact still references the old
+// package names. Published npm content is immutable, so a residual that
+// slips into a release can only be fixed by a full version bump — catch it here.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGES_DIR = path.resolve(__dirname, '../packages');
+
+const CODE_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts', '.vue', '.json']);
+const RESIDUAL_PATTERNS = [
+    { name: 'scoped specifier', regex: /['"`]@primevue\// },
+    { name: 'subpath specifier', regex: /['"`]primevue\// },
+    { name: 'bare import', regex: /(?:\bfrom|\brequire\s*\(|\bimport\s*\()\s*['"`]primevue['"`]/ }
+];
+
+function* walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) yield* walk(full);
+        else yield full;
+    }
+}
+
+const findings = [];
+
+// the migrate codemod legitimately contains primevue string literals — it renames them
+const EXCLUDED_PACKAGES = new Set(['migrate']);
+
+for (const pkg of fs.readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!pkg.isDirectory() || EXCLUDED_PACKAGES.has(pkg.name)) continue;
+
+    const dist = path.join(PACKAGES_DIR, pkg.name, 'dist');
+
+    if (!fs.existsSync(dist)) continue;
+
+    for (const file of walk(dist)) {
+        if (file.endsWith('.map') || !CODE_EXTENSIONS.has(path.extname(file))) continue;
+
+        const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+
+        lines.forEach((line, i) => {
+            for (const { name, regex } of RESIDUAL_PATTERNS) {
+                if (regex.test(line)) {
+                    findings.push(`${path.relative(PACKAGES_DIR, file)}:${i + 1} [${name}] ${line.trim().slice(0, 120)}`);
+                    break;
+                }
+            }
+        });
+    }
+}
+
+if (findings.length) {
+    console.error(`verify-dist: found ${findings.length} residual primevue reference(s) in built packages:\n`);
+    findings.forEach((f) => console.error(`  ${f}`));
+    console.error('\nThese would ship broken imports to npm. Fix the source or generator that produced them and rebuild.');
+    process.exit(1);
+}
+
+console.log('verify-dist: all package dists are clean.');


### PR DESCRIPTION
## Summary

- `@openvue/auto-import-resolver` resolved components to `primevue/...` paths
  instead of `openvue/...`
- `openvue`'s root barrel (`index.mjs` / `index.d.ts`) still self-referenced
  `primevue/...` internally, breaking Vite resolution and causing
  `Module '"openvue"' has no exported member 'useToast'` under `tsc`
- `packages/icons/scripts/prebuild.mjs` — the icons barrel generator itself
  still emitted `@primevue/icons/...` templates, regenerating a broken
  `src/index.js` / `index.d.ts` on every build
  