### PR TITLE
fix: drop aria-level from menuitem components

### DIFF
--- a/packages/primevue/src/contextmenu/ContextMenu.spec.js
+++ b/packages/primevue/src/contextmenu/ContextMenu.spec.js
@@ -156,6 +156,17 @@ describe('ContextMenu.vue', () => {
         expect(wrapper.find('.p-contextmenu.p-component').exists()).toBe(true);
         expect(wrapper.findAll('.p-contextmenu-item').length).toBe(5);
         expect(wrapper.findAll('.p-contextmenu-item-label')[0].text()).toBe('File');
+
+        const menuitems = wrapper.findAll('[role="menuitem"]');
+
+        expect(menuitems.length).toBe(5);
+        menuitems.forEach((item) => {
+            expect(item.attributes('aria-level')).toBeUndefined();
+            expect(item.attributes('aria-setsize')).toBe('5');
+        });
+        expect(menuitems[0].attributes('aria-posinset')).toBe('1');
+        expect(menuitems[4].attributes('aria-label')).toBe('Quit');
+        expect(menuitems[4].attributes('aria-posinset')).toBe('5');
     });
 
     it('should hide menu', async () => {

--- a/packages/primevue/src/contextmenu/ContextMenuSub.vue
+++ b/packages/primevue/src/contextmenu/ContextMenuSub.vue
@@ -12,7 +12,6 @@
                     :aria-disabled="isItemDisabled(processedItem) || undefined"
                     :aria-expanded="isItemGroup(processedItem) ? isItemActive(processedItem) : undefined"
                     :aria-haspopup="isItemGroup(processedItem) && !getItemProp(processedItem, 'to') ? 'menu' : undefined"
-                    :aria-level="level + 1"
                     :aria-setsize="getAriaSetSize()"
                     :aria-posinset="getAriaPosInset(index)"
                     v-bind="getPTOptions('item', processedItem, index)"

--- a/packages/primevue/src/megamenu/MegaMenu.spec.js
+++ b/packages/primevue/src/megamenu/MegaMenu.spec.js
@@ -64,6 +64,15 @@ describe('MegaMenu.vue', () => {
         expect(wrapper.findAll('li.p-megamenu-item')[0].findAll('span.p-megamenu-item-label')[0].text()).toBe('Videos');
         expect(wrapper.findAll('li.p-megamenu-submenu-label')[0].text()).toBe('Video 1');
         expect(wrapper.findAll('li.p-megamenu-item')[1].findAll('span.p-megamenu-item-label')[0].text()).toBe('Video 1.1');
+
+        const menuitems = wrapper.findAll('[role="menuitem"]');
+
+        expect(menuitems.length).toBeGreaterThan(0);
+        menuitems.forEach((item) => {
+            expect(item.attributes('aria-level')).toBeUndefined();
+            expect(item.attributes('aria-setsize')).toBeTruthy();
+            expect(item.attributes('aria-posinset')).toBeTruthy();
+        });
     });
 
     it('should select item', async () => {

--- a/packages/primevue/src/megamenu/MegaMenuSub.vue
+++ b/packages/primevue/src/megamenu/MegaMenuSub.vue
@@ -12,7 +12,6 @@
                 :aria-disabled="isItemDisabled(processedItem) || undefined"
                 :aria-expanded="isItemGroup(processedItem) ? isItemActive(processedItem) : undefined"
                 :aria-haspopup="isItemGroup(processedItem) && !getItemProp(processedItem, 'to') ? 'menu' : undefined"
-                :aria-level="level + 1"
                 :aria-setsize="getAriaSetSize()"
                 :aria-posinset="getAriaPosInset(index)"
                 v-bind="getPTOptions(processedItem, index, 'item')"

--- a/packages/primevue/src/menubar/Menubar.spec.js
+++ b/packages/primevue/src/menubar/Menubar.spec.js
@@ -64,6 +64,20 @@ describe('Menubar.vue', () => {
         expect(wrapper.findAll('ul.p-menubar-submenu')[0].findAll('li.p-menubar-item')[0].find('.p-menubar-item-label').text()).toBe('New');
         expect(wrapper.findAll('li.p-menubar-item').length).toBe(7);
         expect(wrapper.findAll('li.p-menubar-separator').length).toBe(1);
+
+        const menuitems = wrapper.findAll('[role="menuitem"]');
+
+        expect(menuitems.length).toBeGreaterThan(0);
+        menuitems.forEach((item) => {
+            expect(item.attributes('aria-level')).toBeUndefined();
+            expect(item.attributes('aria-setsize')).toBeTruthy();
+            expect(item.attributes('aria-posinset')).toBeTruthy();
+        });
+
+        const exportItem = menuitems.find((item) => item.attributes('aria-label') === 'Export');
+
+        expect(exportItem.attributes('aria-setsize')).toBe('3');
+        expect(exportItem.attributes('aria-posinset')).toBe('3');
     });
 
     it('should slot visible', () => {

--- a/packages/primevue/src/tieredmenu/TieredMenu.spec.js
+++ b/packages/primevue/src/tieredmenu/TieredMenu.spec.js
@@ -1,0 +1,48 @@
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'openvue/config';
+import TieredMenu from './TieredMenu.vue';
+
+describe('TieredMenu.vue', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = mount(TieredMenu, {
+            global: {
+                plugins: [PrimeVue],
+                stubs: {
+                    'router-link': true,
+                    teleport: true
+                }
+            },
+            props: {
+                model: [
+                    {
+                        label: 'File',
+                        items: [{ label: 'New' }, { label: 'Open' }]
+                    },
+                    { separator: true },
+                    { label: 'Quit' }
+                ]
+            }
+        });
+    });
+
+    it('should exist', () => {
+        expect(wrapper.find('.p-tieredmenu.p-component').exists()).toBe(true);
+        expect(wrapper.findAll('[role="menuitem"]').length).toBe(2);
+    });
+
+    it('should omit aria-level and keep setsize/posinset skipping separators', () => {
+        const menuitems = wrapper.findAll('[role="menuitem"]');
+
+        expect(menuitems.length).toBe(2);
+        menuitems.forEach((item) => {
+            expect(item.attributes('aria-level')).toBeUndefined();
+            expect(item.attributes('aria-setsize')).toBe('2');
+        });
+        expect(menuitems[0].attributes('aria-label')).toBe('File');
+        expect(menuitems[0].attributes('aria-posinset')).toBe('1');
+        expect(menuitems[1].attributes('aria-label')).toBe('Quit');
+        expect(menuitems[1].attributes('aria-posinset')).toBe('2');
+    });
+});

--- a/packages/primevue/src/tieredmenu/TieredMenuSub.vue
+++ b/packages/primevue/src/tieredmenu/TieredMenuSub.vue
@@ -12,7 +12,6 @@
                     :aria-disabled="isItemDisabled(processedItem) || undefined"
                     :aria-expanded="isItemGroup(processedItem) ? isItemActive(processedItem) : undefined"
                     :aria-haspopup="isItemGroup(processedItem) && !getItemProp(processedItem, 'to') ? 'menu' : undefined"
-                    :aria-level="level + 1"
                     :aria-setsize="getAriaSetSize()"
                     :aria-posinset="getAriaPosInset(index)"
                     v-bind="getPTOptions(processedItem, index, 'item')"


### PR DESCRIPTION
## Summary
- Remove `aria-level` from `role="menuitem"` on ContextMenu, TieredMenu, and MegaMenu. It is not allowed on `menuitem` and is an axe `aria-allowed-attr` violation.
- Leave `aria-setsize` and `aria-posinset` in place (including Menubar). They are allowed on `menuitem`.
- `<Menu>` was never affected. PanelMenu / CascadeSelect still use `treeitem`, where `aria-level` is valid.

Fixes #43

