### PR TITLE
fix(treetable): don't sort when clicking the filter menu button on a …

### DIFF
--- a/packages/primevue/src/treetable/TreeTable.spec.js
+++ b/packages/primevue/src/treetable/TreeTable.spec.js
@@ -87,7 +87,7 @@ const treeTableOf = (wrapper) => wrapper.findComponent(TreeTable);
 
 const advancedTemplate = `
     <TreeTable :value="nodes" v-model:filters="filters" :filterMode="filterMode" :filterDisplay="filterDisplay" :globalFilterFields="globalFilterFields">
-        <Column field="name" header="Name" expander>
+        <Column field="name" header="Name" expander :sortable="sortableName">
             <template v-if="withFilterSlots" #filter="{ filterModel }">
                 <input class="name-filter" type="text" v-model="filterModel.value" />
             </template>
@@ -112,12 +112,12 @@ const rowFilters = () => ({
 });
 
 // the filter slots use the filterDisplay scope (filterModel), so they are only rendered for the filterDisplay tests
-const mountAdvanced = ({ filters, filterMode = 'lenient', filterDisplay = null, globalFilterFields = null, withFilterSlots = !!filterDisplay } = {}) =>
+const mountAdvanced = ({ filters, filterMode = 'lenient', filterDisplay = null, globalFilterFields = null, withFilterSlots = !!filterDisplay, sortableName = false } = {}) =>
     mount(
         {
             components: { TreeTable, Column },
             data() {
-                return { nodes: createNodes(), filters, filterMode, filterDisplay, globalFilterFields, withFilterSlots };
+                return { nodes: createNodes(), filters, filterMode, filterDisplay, globalFilterFields, withFilterSlots, sortableName };
             },
             template: advancedTemplate
         },
@@ -382,6 +382,26 @@ describe('TreeTable', () => {
             expect(headerRows.length).toBe(1);
             expect(headerRows[0].findAll('.p-treetable-filter.p-treetable-popover-filter').length).toBe(2);
             expect(headerRows[0].findAll('.p-treetable-column-filter-button').length).toBe(2);
+
+            wrapper.unmount();
+        });
+
+        it('should open the filter menu without sorting when the column is sortable', async () => {
+            const wrapper = mountAdvanced({ filters: menuFilters(), filterDisplay: 'menu', sortableName: true });
+
+            await nextTick();
+
+            const treeTable = treeTableOf(wrapper);
+
+            expect(wrapper.find('th[data-p-sortable-column="true"] .p-treetable-column-filter-button').exists()).toBe(true);
+
+            await wrapper.find('.p-treetable-column-filter-button').trigger('click');
+            await nextTick();
+
+            expect(document.querySelector('.p-treetable-filter-overlay')).not.toBeNull();
+            expect(treeTable.vm.d_sortField).toBeNull();
+            expect(treeTable.emitted('update:sortField')).toBeUndefined();
+            expect(treeTable.emitted('sort')).toBeUndefined();
 
             wrapper.unmount();
         });

--- a/packages/primevue/src/treetable/TreeTable.vue
+++ b/packages/primevue/src/treetable/TreeTable.vue
@@ -231,7 +231,7 @@
 
 <script>
 import { cn } from '@openuxkit/utils';
-import { addStyle, clearSelection, find, getAttribute, getIndex, getOffset, getOuterWidth, isRTL, setAttribute } from '@openuxkit/utils/dom';
+import { addStyle, clearSelection, find, getAttribute, getIndex, getOffset, getOuterWidth, isClickable, isRTL, setAttribute } from '@openuxkit/utils/dom';
 import { localeComparator, resolveFieldData, sort } from '@openuxkit/utils/object';
 import { FilterMatchMode, FilterOperator, FilterService } from '@openvue/core/api';
 import { getVNodeProp, HelperSet } from '@openvue/core/utils';
@@ -474,7 +474,7 @@ export default {
                     getAttribute(targetNode, 'data-pc-section') === 'sorticon' ||
                     getAttribute(targetNode.parentElement, 'data-pc-section') === 'sorticon' ||
                     getAttribute(targetNode.parentElement.parentElement, 'data-pc-section') === 'sorticon' ||
-                    targetNode.closest('[data-p-sortable-column="true"]')
+                    (targetNode.closest('[data-p-sortable-column="true"]') && !targetNode.closest('[data-pc-section="columnfilterbutton"]') && !isClickable(event.target))
                 ) {
                     clearSelection();
 


### PR DESCRIPTION
### What does this PR do?

Stops `TreeTable` from sorting a column when you click its filter menu button.

On a column that is both `sortable` and uses `filterDisplay="menu"`, the filter control
renders inside the sortable `th`, and the toggle handler calls `preventDefault` without
stopping propagation. The header click handler ended on a bare
`closest('[data-p-sortable-column="true"]')`, so one click opened the overlay *and*
toggled the sort.

`DataTable` already guards against exactly this. This ports the same guard over: the
`closest` branch now also requires that the target is not inside the `columnfilterbutton`
section and is not a clickable element.

### Related issue

Follow-up to #638.